### PR TITLE
feat: N-level deep relational path filtering for O2M and M2O

### DIFF
--- a/examples/example_async.py
+++ b/examples/example_async.py
@@ -35,10 +35,37 @@ class Base(DeclarativeBase):
     pass
 
 
+class Country(Base):
+    __tablename__ = "countries"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(100))
+
+
+class City(Base):
+    __tablename__ = "cities"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(100))
+    country_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("countries.id"), nullable=True
+    )
+    country: Mapped[Optional["Country"]] = relationship()
+
+
+class Product(Base):
+    __tablename__ = "products"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(100))
+    category: Mapped[str] = mapped_column(String(100))
+
+
 class Customer(Base):
     __tablename__ = "customers"
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str] = mapped_column(String(100))
+    city_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("cities.id"), nullable=True
+    )
+    city: Mapped[Optional["City"]] = relationship()
 
     def __repr__(self) -> str:
         return f"Customer(id={self.id}, name={self.name!r})"
@@ -67,6 +94,10 @@ class OrderLine(Base):
     product_name: Mapped[str] = mapped_column(String(100))
     quantity: Mapped[int] = mapped_column()
     unit_price: Mapped[int] = mapped_column()
+    product_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("products.id"), nullable=True
+    )
+    product: Mapped[Optional["Product"]] = relationship()
     order: Mapped["Order"] = relationship(back_populates="lines")
 
 
@@ -74,10 +105,28 @@ class OrderLine(Base):
 
 
 async def seed(session: AsyncSession) -> None:
+    session.add_all([Country(id=1, name="India"), Country(id=2, name="USA")])
+    await session.flush()
     session.add_all(
         [
-            Customer(id=1, name="Joy"),
-            Customer(id=2, name="Bob"),
+            City(id=1, name="Mumbai", country_id=1),
+            City(id=2, name="New York", country_id=2),
+        ]
+    )
+    await session.flush()
+    session.add_all(
+        [
+            Product(id=1, name="Widget A", category="Hardware"),
+            Product(id=2, name="Widget B", category="Hardware"),
+            Product(id=3, name="Gadget", category="Electronics"),
+            Product(id=4, name="Accessory", category="Electronics"),
+        ]
+    )
+    await session.flush()
+    session.add_all(
+        [
+            Customer(id=1, name="Joy", city_id=1),  # Mumbai, India
+            Customer(id=2, name="Bob", city_id=2),  # New York, USA
         ]
     )
     await session.flush()
@@ -116,10 +165,10 @@ async def seed(session: AsyncSession) -> None:
     await session.flush()
     session.add_all(
         [
-            OrderLine(order_id=1, product_name="Widget A", quantity=2, unit_price=50),
-            OrderLine(order_id=1, product_name="Widget B", quantity=3, unit_price=50),
-            OrderLine(order_id=2, product_name="Gadget", quantity=1, unit_price=200),
-            OrderLine(order_id=4, product_name="Accessory", quantity=5, unit_price=15),
+            OrderLine(order_id=1, product_name="Widget A", quantity=2, unit_price=50, product_id=1),
+            OrderLine(order_id=1, product_name="Widget B", quantity=3, unit_price=50, product_id=2),
+            OrderLine(order_id=2, product_name="Gadget", quantity=1, unit_price=200, product_id=3),
+            OrderLine(order_id=4, product_name="Accessory", quantity=5, unit_price=15, product_id=4),
         ]
     )
     await session.commit()
@@ -368,6 +417,29 @@ async def main() -> None:
             ),
         )
 
+        # ── Section 8b: N-level relational filtering ─────────────────────
+
+        section("8b. N-level relational filtering (deep dot-notation)")
+
+        show(
+            "2-level M2O — orders where customer.city.name = 'Mumbai'",
+            await engine.alist(session, domain=[["customer.city.name", "=", "Mumbai"]]),
+        )
+
+        show(
+            "3-level M2O — orders where customer.city.country.name ilike '%Ind%'",
+            await engine.alist(
+                session, domain=[["customer.city.country.name", "ilike", "%Ind%"]]
+            ),
+        )
+
+        show(
+            "O2M → M2O — orders with a line whose product.category = 'Electronics'",
+            await engine.alist(
+                session, domain=[["lines.product.category", "=", "Electronics"]]
+            ),
+        )
+
         # ── Section 9: alist() options ────────────────────────────────────
 
         section("9. alist() — limit, offset, order_by")
@@ -437,6 +509,17 @@ async def main() -> None:
             aggregates=["__count", "lines.quantity:sum", "lines.unit_price:avg"],
         )
         show_groups("line qty sum + unit_price avg per status", groups, total)
+
+        # ── Section 12b: aread_group — N-level deep groupby ──────────────
+
+        section("13b. aread_group — deep relational groupby (O2M → M2O)")
+
+        groups, total = await engine.aread_group(
+            session,
+            groupby=["lines.product.category"],
+            aggregates=["lines.quantity:sum"],
+        )
+        show_groups("sum of line quantities per product category", groups, total)
 
         # ── Section 13: aread_group — HAVING ──────────────────────────────
 

--- a/examples/example_sync.py
+++ b/examples/example_sync.py
@@ -36,10 +36,37 @@ class Base(DeclarativeBase):
     pass
 
 
+class Country(Base):
+    __tablename__ = "countries"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(100))
+
+
+class City(Base):
+    __tablename__ = "cities"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(100))
+    country_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("countries.id"), nullable=True
+    )
+    country: Mapped[Optional["Country"]] = relationship()
+
+
+class Product(Base):
+    __tablename__ = "products"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(100))
+    category: Mapped[str] = mapped_column(String(100))
+
+
 class Customer(Base):
     __tablename__ = "customers"
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str] = mapped_column(String(100))
+    city_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("cities.id"), nullable=True
+    )
+    city: Mapped[Optional["City"]] = relationship()
 
     def __repr__(self) -> str:
         return f"Customer(id={self.id}, name={self.name!r})"
@@ -68,6 +95,10 @@ class OrderLine(Base):
     product_name: Mapped[str] = mapped_column(String(100))
     quantity: Mapped[int] = mapped_column()
     unit_price: Mapped[int] = mapped_column()
+    product_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("products.id"), nullable=True
+    )
+    product: Mapped[Optional["Product"]] = relationship()
     order: Mapped["Order"] = relationship(back_populates="lines")
 
 
@@ -77,8 +108,31 @@ class OrderLine(Base):
 def seed(session: Session) -> None:
     session.add_all(
         [
-            Customer(id=1, name="Joy"),
-            Customer(id=2, name="Bob"),
+            Country(id=1, name="India"),
+            Country(id=2, name="USA"),
+        ]
+    )
+    session.flush()
+    session.add_all(
+        [
+            City(id=1, name="Mumbai", country_id=1),
+            City(id=2, name="New York", country_id=2),
+        ]
+    )
+    session.flush()
+    session.add_all(
+        [
+            Product(id=1, name="Widget A", category="Hardware"),
+            Product(id=2, name="Widget B", category="Hardware"),
+            Product(id=3, name="Gadget", category="Electronics"),
+            Product(id=4, name="Accessory", category="Electronics"),
+        ]
+    )
+    session.flush()
+    session.add_all(
+        [
+            Customer(id=1, name="Joy", city_id=1),  # Mumbai, India
+            Customer(id=2, name="Bob", city_id=2),  # New York, USA
         ]
     )
     session.flush()
@@ -117,10 +171,10 @@ def seed(session: Session) -> None:
     session.flush()
     session.add_all(
         [
-            OrderLine(order_id=1, product_name="Widget A", quantity=2, unit_price=50),
-            OrderLine(order_id=1, product_name="Widget B", quantity=3, unit_price=50),
-            OrderLine(order_id=2, product_name="Gadget", quantity=1, unit_price=200),
-            OrderLine(order_id=4, product_name="Accessory", quantity=5, unit_price=15),
+            OrderLine(order_id=1, product_name="Widget A", quantity=2, unit_price=50, product_id=1),
+            OrderLine(order_id=1, product_name="Widget B", quantity=3, unit_price=50, product_id=2),
+            OrderLine(order_id=2, product_name="Gadget", quantity=1, unit_price=200, product_id=3),
+            OrderLine(order_id=4, product_name="Accessory", quantity=5, unit_price=15, product_id=4),
         ]
     )
     session.commit()
@@ -364,6 +418,27 @@ def main() -> None:
             ),
         )
 
+        # ── Section 8b: N-level relational filtering ─────────────────────
+
+        section("8b. N-level relational filtering (deep dot-notation)")
+
+        show(
+            "2-level M2O — orders where customer.city.name = 'Mumbai'",
+            engine.list(session, domain=[["customer.city.name", "=", "Mumbai"]]),
+        )
+
+        show(
+            "3-level M2O — orders where customer.city.country.name ilike '%Ind%'",
+            engine.list(
+                session, domain=[["customer.city.country.name", "ilike", "%Ind%"]]
+            ),
+        )
+
+        show(
+            "O2M → M2O — orders with a line whose product.category = 'Electronics'",
+            engine.list(session, domain=[["lines.product.category", "=", "Electronics"]]),
+        )
+
         # ── Section 9: list() options ─────────────────────────────────────
 
         section("9. list() — limit, offset, order_by")
@@ -424,6 +499,17 @@ def main() -> None:
             aggregates=["__count", "lines.quantity:sum"],
         )
         show_groups("sum of line quantities per status", groups, total)
+
+        # ── Section 12b: read_group — N-level deep groupby ───────────────
+
+        section("13b. read_group — deep relational groupby (O2M → M2O)")
+
+        groups, total = engine.read_group(
+            session,
+            groupby=["lines.product.category"],
+            aggregates=["lines.quantity:sum"],
+        )
+        show_groups("sum of line quantities per product category", groups, total)
 
         # ── Section 13: read_group — HAVING ──────────────────────────────
 

--- a/src/axiom_query/aggregation.py
+++ b/src/axiom_query/aggregation.py
@@ -100,12 +100,15 @@ class ReadGroupQuery:
         return m
 
     @property
-    def referenced_child_entities(self) -> set[str]:
-        children: set[str] = set()
+    def referenced_relation_paths(self) -> set[tuple[str, ...]]:
+        """Distinct relation-path prefixes (everything but the leaf field) across
+        all groupby + aggregate field paths. E.g. "lines.product.category"
+        contributes the prefix ("lines", "product")."""
+        paths: set[tuple[str, ...]] = set()
         for g in self.groupby:
             if "." in g.field_path:
-                children.add(g.field_path.split(".")[0])
+                paths.add(tuple(g.field_path.split(".")[:-1]))
         for a in self.aggregates:
             if a.field_path and "." in a.field_path:
-                children.add(a.field_path.split(".")[0])
-        return children
+                paths.add(tuple(a.field_path.split(".")[:-1]))
+        return paths

--- a/src/axiom_query/compiler.py
+++ b/src/axiom_query/compiler.py
@@ -10,7 +10,7 @@ from sqlalchemy.sql.expression import ColumnElement
 
 from axiom_query.ast import And, Bool, Condition, Not, Or, QuerySpec
 from axiom_query.operators import Op
-from axiom_query.schema import ModelSchema
+from axiom_query.schema import ModelSchema, derive_schema
 
 SAResolver = Callable[[str, Op, Any], ColumnElement]
 
@@ -89,48 +89,58 @@ def _resolve_column(schema: ModelSchema, field_path: str) -> ColumnElement:
         return schema.table.c[field_path]
 
 
+def _resolve_path_condition(
+    schema: ModelSchema, segments: list[str], op: Op, val: Any
+) -> ColumnElement:
+    """Resolve a (possibly multi-hop) relational path into a WHERE condition.
+
+    The leaf segment is a scalar column; every preceding segment is an O2M or
+    M2O relation, each wrapped in a correlated EXISTS so arbitrary depth and
+    mixed O2M/M2O chains are supported.
+    """
+    from axiom_query.errors import QueryError
+
+    head, *rest = segments
+
+    # Leaf: scalar column on the current model
+    if not rest:
+        return _apply_operator(_resolve_column(schema, head), op, val)
+
+    # O2M: FK is on the child table; correlate child rows to the parent PK
+    child = schema.children.get(head)
+    if child is not None:
+        inner = _resolve_path_condition(derive_schema(child.model_class), rest, op, val)
+        parent_pk = next(iter(schema.table.primary_key))
+        return exists(
+            select(1)
+            .select_from(child.table)
+            .where(and_(child.table.c[child.fk_field] == parent_pk, inner))
+        )
+
+    # M2O: FK is on the current table; correlate the referenced PK to the local FK
+    related = schema.related.get(head)
+    if related is not None:
+        inner = _resolve_path_condition(derive_schema(related.model_class), rest, op, val)
+        ref_pk = next(iter(related.table.primary_key))
+        return exists(
+            select(1)
+            .select_from(related.table)
+            .where(and_(ref_pk == schema.table.c[related.fk_field], inner))
+        )
+
+    all_relations = list(schema.children.keys()) + list(schema.related.keys())
+    raise QueryError(
+        "INVALID_FILTER_FIELD",
+        f"No relation '{head}' on {schema.model_class.__name__}. "
+        f"Available: {', '.join(all_relations) or 'none'}",
+    )
+
+
 def _make_table_resolver(schema: ModelSchema) -> SAResolver:
     """Create a WHERE resolver that resolves field paths against table columns."""
 
     def resolve(fp: str, op: Op, val: Any) -> ColumnElement:
-        if "." in fp:
-            rel_name, field_name = fp.split(".", 1)
-            from axiom_query.errors import QueryError
-
-            # O2M: FK is on the child table; use EXISTS over child rows
-            child = schema.children.get(rel_name)
-            if child is not None:
-                fk_col = child.table.c[child.fk_field]
-                field_col = child.table.c[field_name]
-                condition = _apply_operator(field_col, op, val)
-                return exists(
-                    select(1)
-                    .select_from(child.table)
-                    .where(and_(fk_col == schema.table.c.id, condition))
-                )
-
-            # M2O: FK is on the current table; use EXISTS over the referenced table
-            related = schema.related.get(rel_name)
-            if related is not None:
-                local_fk_col = schema.table.c[related.fk_field]
-                ref_pk = next(iter(related.table.primary_key))
-                field_col = related.table.c[field_name]
-                condition = _apply_operator(field_col, op, val)
-                return exists(
-                    select(1)
-                    .select_from(related.table)
-                    .where(and_(ref_pk == local_fk_col, condition))
-                )
-
-            all_relations = list(schema.children.keys()) + list(schema.related.keys())
-            raise QueryError(
-                "INVALID_FILTER_FIELD",
-                f"No relation '{rel_name}' on {schema.model_class.__name__}. "
-                f"Available: {', '.join(all_relations) or 'none'}",
-            )
-        else:
-            col = _resolve_column(schema, fp)
-            return _apply_operator(col, op, val)
+        return _resolve_path_condition(schema, fp.split("."), op, val)
 
     return resolve
 

--- a/src/axiom_query/compiler_aggregate.py
+++ b/src/axiom_query/compiler_aggregate.py
@@ -18,7 +18,7 @@ from axiom_query.aggregation import (
     ReadGroupQuery,
 )
 from axiom_query.compiler import _walk_ast, _make_alias_resolver
-from axiom_query.schema import ModelSchema
+from axiom_query.schema import ModelSchema, derive_schema
 
 
 def compile_read_group(
@@ -30,31 +30,18 @@ def compile_read_group(
     """Compile a ReadGroupQuery into a SQLAlchemy SELECT statement."""
     from axiom_query.errors import QueryError
 
-    # Multi-child guard
-    child_entities = query.referenced_child_entities
-    if len(child_entities) > 1:
+    # Build the JOIN chain spanning every relational path (O2M and M2O, N-level deep).
+    from_clause, alias_cache, o2m_edges = _build_join_tree(
+        schema, query.referenced_relation_paths
+    )
+
+    # O2M fan-out double-counts aggregates; allow at most one O2M edge in the tree.
+    if o2m_edges > 1:
         raise QueryError(
             "MULTI_CHILD_AGGREGATION",
-            f"Aggregating across multiple child entities simultaneously is not supported "
-            f"(referenced: {', '.join(sorted(child_entities))}). "
-            f"Aggregate one child entity at a time.",
-        )
-
-    # Build JOINs for child entities
-    from_clause = schema.table
-    joined_children: dict[str, Any] = {}
-
-    for child_name in child_entities:
-        child = schema.children.get(child_name)
-        if child is None:
-            raise QueryError(
-                "INVALID_FILTER_FIELD",
-                f"No child relation '{child_name}' on {schema.model_class.__name__}",
-            )
-        joined_children[child_name] = child
-        from_clause = from_clause.outerjoin(
-            child.table,
-            schema.table.c.id == child.table.c[child.fk_field],
+            "Aggregating across multiple O2M child entities simultaneously is not "
+            "supported (the join would fan out and double-count). "
+            "Aggregate one O2M child branch at a time.",
         )
 
     # Build SELECT columns
@@ -62,13 +49,13 @@ def compile_read_group(
     groupby_exprs: dict[str, ColumnElement] = {}
 
     for g in query.groupby:
-        expr = _compile_groupby_column(g, schema, joined_children, dialect_name)
+        expr = _compile_groupby_column(g, schema, alias_cache, dialect_name)
         groupby_exprs[g.alias] = expr
         select_columns.append(expr.label(g.alias))
 
     aggregate_exprs: dict[str, ColumnElement] = {}
     for a in query.aggregates:
-        expr = _compile_aggregate_column(a, schema, joined_children)
+        expr = _compile_aggregate_column(a, schema, alias_cache)
         aggregate_exprs[a.alias] = expr
         select_columns.append(expr.label(a.alias))
 
@@ -128,13 +115,62 @@ def _date_trunc_expr(granularity: DateGranularity, col: ColumnElement, dialect_n
         return func.date_trunc(granularity.value, col).cast(SADate)
 
 
+def _build_join_tree(
+    schema: ModelSchema, paths: set[tuple[str, ...]]
+) -> tuple[Any, dict[tuple[str, ...], tuple[Any, ModelSchema]], int]:
+    """Build an outer-join chain covering every relation-path prefix.
+
+    Returns the FROM clause, a cache mapping each path prefix to its
+    (aliased table, schema), and the number of O2M edges traversed. Shared
+    prefixes reuse a single join; divergent paths get distinct aliases.
+    """
+    from axiom_query.errors import QueryError
+
+    from_clause: Any = schema.table
+    alias_cache: dict[tuple[str, ...], tuple[Any, ModelSchema]] = {(): (schema.table, schema)}
+    o2m_edges = 0
+
+    for path in sorted(paths, key=len):
+        for i in range(1, len(path) + 1):
+            prefix = path[:i]
+            if prefix in alias_cache:
+                continue
+            parent_table, parent_schema = alias_cache[prefix[:-1]]
+            seg = prefix[-1]
+            child = parent_schema.children.get(seg)
+            related = parent_schema.related.get(seg)
+            if child is not None:
+                next_schema = derive_schema(child.model_class)
+                alias = next_schema.table.alias()
+                parent_pk = next(iter(parent_schema.table.primary_key)).name
+                from_clause = from_clause.outerjoin(
+                    alias, parent_table.c[parent_pk] == alias.c[child.fk_field]
+                )
+                o2m_edges += 1
+            elif related is not None:
+                next_schema = derive_schema(related.model_class)
+                alias = next_schema.table.alias()
+                ref_pk = next(iter(next_schema.table.primary_key)).name
+                from_clause = from_clause.outerjoin(
+                    alias, parent_table.c[related.fk_field] == alias.c[ref_pk]
+                )
+            else:
+                raise QueryError(
+                    "INVALID_FILTER_FIELD",
+                    f"No relation '{seg}' on {parent_schema.model_class.__name__}",
+                )
+            alias_cache[prefix] = (alias, next_schema)
+
+    return from_clause, alias_cache, o2m_edges
+
+
 def _compile_groupby_column(
     spec: GroupBySpec,
     schema: ModelSchema,
-    joined_children: dict,
+    alias_cache: dict,
     dialect_name: str,
 ) -> ColumnElement:
-    col = _resolve_agg_column(spec.field_path, schema, joined_children)
+    col = _resolve_agg_column(spec.field_path, schema, alias_cache)
 
     if spec.granularity is None:
         return col
@@ -147,7 +183,7 @@ def _compile_groupby_column(
 def _compile_aggregate_column(
     spec: AggregateSpec,
     schema: ModelSchema,
-    joined_children: dict,
+    alias_cache: dict,
 ) -> ColumnElement:
     from axiom_query.errors import QueryError
 
@@ -159,7 +195,7 @@ def _compile_aggregate_column(
             )
         return func.count()
 
-    col = _resolve_agg_column(spec.field_path, schema, joined_children)
+    col = _resolve_agg_column(spec.field_path, schema, alias_cache)
 
     if spec.function in (AggFunc.SUM, AggFunc.AVG):
         _validate_numeric_col(spec.field_path, col)
@@ -186,19 +222,27 @@ def _compile_aggregate_column(
 def _resolve_agg_column(
     field_path: str,
     schema: ModelSchema,
-    joined_children: dict,
+    alias_cache: dict,
 ) -> ColumnElement:
     from axiom_query.errors import QueryError
 
     if "." in field_path:
-        child_name, field_name = field_path.split(".", 1)
-        child = joined_children.get(child_name) or schema.children.get(child_name)
-        if child is None:
+        segments = field_path.split(".")
+        prefix = tuple(segments[:-1])
+        leaf = segments[-1]
+        entry = alias_cache.get(prefix)
+        if entry is None:
             raise QueryError(
                 "INVALID_FILTER_FIELD",
-                f"No child relation '{child_name}' on {schema.model_class.__name__}",
+                f"No relation path '{'.'.join(prefix)}' on {schema.model_class.__name__}",
             )
-        return child.table.c[field_name]
+        table, leaf_schema = entry
+        if leaf not in leaf_schema.columns:
+            raise QueryError(
+                "INVALID_FILTER_FIELD",
+                f"No field '{leaf}' on relation path '{'.'.join(prefix)}'",
+            )
+        return table.c[leaf]
     else:
         if field_path not in schema.columns:
             raise QueryError(

--- a/src/axiom_query/schema.py
+++ b/src/axiom_query/schema.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from functools import lru_cache
 
 from sqlalchemy import Column, Table
 from sqlalchemy import inspect as sa_inspect
@@ -15,6 +16,7 @@ class ChildSchema:
     table: Table
     fk_field: str
     columns: dict[str, Column]
+    model_class: type  # comodel class, enables N-level path traversal
 
 
 @dataclass
@@ -29,6 +31,7 @@ class RelatedSchema:
     table: Table
     fk_field: str  # FK column name on the current (owning) table
     columns: dict[str, Column]
+    model_class: type  # comodel class, enables N-level path traversal
 
 
 @dataclass
@@ -40,8 +43,14 @@ class ModelSchema:
     related: dict[str, RelatedSchema] = field(default_factory=dict)
 
 
+@lru_cache(maxsize=None)
 def derive_schema(model_class: type) -> ModelSchema:
-    """Derive a ModelSchema from a SA ORM model class using inspect()."""
+    """Derive a ModelSchema from a SA ORM model class using inspect().
+
+    Cached per model_class: schemas are derived on demand while traversing
+    N-level relational paths, and caching keeps cyclic relations
+    (Order.lines -> OrderLine.order -> Order ...) from re-deriving endlessly.
+    """
     mapper = sa_inspect(model_class)
     table = mapper.local_table
     columns = {col.key: col for col in mapper.columns}
@@ -59,6 +68,7 @@ def derive_schema(model_class: type) -> ModelSchema:
                 table=child_table,
                 fk_field=child_fk_col.key,
                 columns=child_columns,
+                model_class=rel.mapper.class_,
             )
         elif rel.direction == RelationshipDirection.MANYTOONE:
             ref_table = rel.mapper.local_table
@@ -70,6 +80,7 @@ def derive_schema(model_class: type) -> ModelSchema:
                 table=ref_table,
                 fk_field=local_fk_col.key,
                 columns=ref_columns,
+                model_class=rel.mapper.class_,
             )
 
     return ModelSchema(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,10 +16,33 @@ class Base(DeclarativeBase):
     pass
 
 
+class Country(Base):
+    __tablename__ = "countries"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(100))
+
+
+class City(Base):
+    __tablename__ = "cities"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(100))
+    country_id: Mapped[Optional[int]] = mapped_column(ForeignKey("countries.id"), nullable=True)
+    country: Mapped[Optional["Country"]] = relationship()
+
+
 class Customer(Base):
     __tablename__ = "customers"
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str] = mapped_column(String(100))
+    city_id: Mapped[Optional[int]] = mapped_column(ForeignKey("cities.id"), nullable=True)
+    city: Mapped[Optional["City"]] = relationship()
+
+
+class Product(Base):
+    __tablename__ = "products"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(100))
+    category: Mapped[str] = mapped_column(String(100))
 
 
 class Order(Base):
@@ -40,6 +63,8 @@ class OrderLine(Base):
     product_name: Mapped[str] = mapped_column(String(100))
     quantity: Mapped[int] = mapped_column()
     unit_price: Mapped[int] = mapped_column()
+    product_id: Mapped[Optional[int]] = mapped_column(ForeignKey("products.id"), nullable=True)
+    product: Mapped[Optional["Product"]] = relationship()
     order: Mapped["Order"] = relationship(back_populates="lines")
 
 
@@ -55,8 +80,25 @@ def db_engine():
 def seeded_engine(db_engine):
     """Seed test data once per session."""
     with Session(db_engine) as sess:
-        c1 = Customer(id=1, name="Alice")
-        c2 = Customer(id=2, name="Bob")
+        india = Country(id=1, name="India")
+        usa = Country(id=2, name="USA")
+        sess.add_all([india, usa])
+        sess.flush()
+
+        mumbai = City(id=1, name="Mumbai", country_id=1)
+        nyc = City(id=2, name="New York", country_id=2)
+        sess.add_all([mumbai, nyc])
+        sess.flush()
+
+        # p2/p3 categories chosen so exactly order 2 has an "Electronics" line
+        p1 = Product(id=1, name="Widget A", category="Hardware")
+        p2 = Product(id=2, name="Widget B", category="Hardware")
+        p3 = Product(id=3, name="Gadget", category="Electronics")
+        sess.add_all([p1, p2, p3])
+        sess.flush()
+
+        c1 = Customer(id=1, name="Alice", city_id=1)  # Mumbai, India
+        c2 = Customer(id=2, name="Bob", city_id=2)  # New York, USA
         sess.add_all([c1, c2])
         sess.flush()
 
@@ -85,10 +127,10 @@ def seeded_engine(db_engine):
         sess.flush()
 
         # Order 1 lines: qty=2 unit_price=50; qty=3 unit_price=50
-        l1 = OrderLine(order_id=1, product_name="Widget A", quantity=2, unit_price=50)
-        l2 = OrderLine(order_id=1, product_name="Widget B", quantity=3, unit_price=50)
-        # Order 2 lines: qty=1 unit_price=200
-        l3 = OrderLine(order_id=2, product_name="Gadget", quantity=1, unit_price=200)
+        l1 = OrderLine(order_id=1, product_name="Widget A", quantity=2, unit_price=50, product_id=1)
+        l2 = OrderLine(order_id=1, product_name="Widget B", quantity=3, unit_price=50, product_id=2)
+        # Order 2 lines: qty=1 unit_price=200 (Gadget → Electronics)
+        l3 = OrderLine(order_id=2, product_name="Gadget", quantity=1, unit_price=200, product_id=3)
         # Order 3: no lines
         sess.add_all([l1, l2, l3])
         sess.commit()
@@ -124,8 +166,19 @@ async def seeded_async_engine(async_db_engine):
     from sqlalchemy.ext.asyncio import AsyncSession
 
     async with AsyncSession(async_db_engine) as sess:
-        c1 = Customer(id=1, name="Alice")
-        c2 = Customer(id=2, name="Bob")
+        sess.add_all([Country(id=1, name="India"), Country(id=2, name="USA")])
+        await sess.flush()
+        sess.add_all([City(id=1, name="Mumbai", country_id=1), City(id=2, name="New York", country_id=2)])
+        await sess.flush()
+        sess.add_all([
+            Product(id=1, name="Widget A", category="Hardware"),
+            Product(id=2, name="Widget B", category="Hardware"),
+            Product(id=3, name="Gadget", category="Electronics"),
+        ])
+        await sess.flush()
+
+        c1 = Customer(id=1, name="Alice", city_id=1)
+        c2 = Customer(id=2, name="Bob", city_id=2)
         sess.add_all([c1, c2])
         await sess.flush()
 
@@ -135,9 +188,9 @@ async def seeded_async_engine(async_db_engine):
         sess.add_all([o1, o2, o3])
         await sess.flush()
 
-        l1 = OrderLine(order_id=1, product_name="Widget A", quantity=2, unit_price=50)
-        l2 = OrderLine(order_id=1, product_name="Widget B", quantity=3, unit_price=50)
-        l3 = OrderLine(order_id=2, product_name="Gadget", quantity=1, unit_price=200)
+        l1 = OrderLine(order_id=1, product_name="Widget A", quantity=2, unit_price=50, product_id=1)
+        l2 = OrderLine(order_id=1, product_name="Widget B", quantity=3, unit_price=50, product_id=2)
+        l3 = OrderLine(order_id=2, product_name="Gadget", quantity=1, unit_price=200, product_id=3)
         sess.add_all([l1, l2, l3])
         await sess.commit()
 

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -19,3 +19,11 @@ async def test_aread_group(async_session, engine):
         async_session, groupby=["status"], aggregates=["__count"]
     )
     assert total == 2
+
+
+@pytest.mark.asyncio
+async def test_alist_nested_relational_path(async_session, engine):
+    # Order → customer (M2O) → city (M2O) → name, over the async path
+    records = await engine.alist(async_session, domain=[["customer.city.name", "=", "Mumbai"]])
+    assert len(records) == 1
+    assert records[0].id == 1

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -89,3 +89,54 @@ def test_list_m2o_unknown_relation_raises(session, engine):
 
     with pytest.raises(QueryError):
         engine.list(session, domain=[["nonexistent.name", "=", "x"]])
+
+
+# Slice 7 — N-level deep relational paths (O2M + M2O, arbitrary depth)
+def test_list_two_level_m2o(session, engine):
+    # Order → customer (M2O) → city (M2O) → name
+    records = engine.list(session, domain=[["customer.city.name", "=", "Mumbai"]])
+    assert len(records) == 1
+    assert records[0].id == 1  # Alice → Mumbai
+
+
+def test_list_three_level_m2o(session, engine):
+    # Order → customer → city → country → name
+    records = engine.list(session, domain=[["customer.city.country.name", "ilike", "%Ind%"]])
+    assert len(records) == 1
+    assert records[0].id == 1  # Alice → Mumbai → India
+
+
+def test_list_o2m_then_m2o(session, engine):
+    # Order → lines (O2M) → product (M2O) → category
+    records = engine.list(session, domain=[["lines.product.category", "=", "Electronics"]])
+    assert len(records) == 1
+    assert records[0].id == 2  # order 2 has the Gadget (Electronics) line
+
+
+def test_list_nested_path_combined_with_scalar(session, engine):
+    # Nested path AND'd with a scalar filter still narrows correctly
+    records = engine.list(
+        session,
+        domain=[["customer.city.name", "=", "Mumbai"], ["status", "=", "CONFIRMED"]],
+    )
+    assert len(records) == 1
+    assert records[0].id == 1
+
+
+def test_list_nested_path_no_match(session, engine):
+    records = engine.list(session, domain=[["customer.city.country.name", "=", "Atlantis"]])
+    assert records == []
+
+
+def test_list_nested_unknown_relation_raises(session, engine):
+    from axiom_query.errors import QueryError
+
+    with pytest.raises(QueryError):
+        engine.list(session, domain=[["customer.nope.name", "=", "x"]])
+
+
+def test_list_nested_unknown_leaf_field_raises(session, engine):
+    from axiom_query.errors import QueryError
+
+    with pytest.raises(QueryError):
+        engine.list(session, domain=[["customer.city.bogus", "=", "x"]])

--- a/tests/test_read_group.py
+++ b/tests/test_read_group.py
@@ -71,3 +71,29 @@ def test_read_group_domain_drilldown(session, engine):
     records = engine.list(session, domain=confirmed["__domain"])
     assert len(records) == 2
     assert all(r.status == "CONFIRMED" for r in records)
+
+
+# Slice 11 — N-level deep relational paths in groupby / aggregate
+def test_read_group_o2m_then_m2o_groupby(session, engine):
+    # group order lines by product category (O2M → M2O), sum line quantities
+    groups, total = engine.read_group(
+        session,
+        groupby=["lines.product.category"],
+        aggregates=["lines.quantity:sum"],
+    )
+    by_cat = {g["lines__product__category"]: g["lines__quantity__sum"] for g in groups}
+    # Hardware: Widget A (2) + Widget B (3) = 5 ; Electronics: Gadget (1)
+    assert by_cat["Hardware"] == 5
+    assert by_cat["Electronics"] == 1
+
+
+def test_read_group_two_level_m2o_groupby(session, engine):
+    # group orders by customer's city name (M2O → M2O)
+    groups, total = engine.read_group(
+        session,
+        groupby=["customer.city.name"],
+        aggregates=["__count"],
+    )
+    by_city = {g["customer__city__name"]: g["__count"] for g in groups}
+    assert by_city["Mumbai"] == 1
+    assert by_city["New York"] == 1


### PR DESCRIPTION
Extend dot-notation filtering to traverse arbitrary-depth relational paths mixing O2M and M2O hops, with no public API change. Previously only a single hop was supported (e.g. lines.quantity, customer.name); now paths like customer.city.country.name and lines.product.category resolve correctly.

- schema: carry the comodel class on ChildSchema/RelatedSchema and cache derive_schema so nested levels can be derived on demand (cycle-safe).
- compiler (WHERE): recursive path resolver wrapping each hop in a correlated EXISTS; depth-1 output is unchanged.
- aggregation: alias-cached multi-hop outer-join chain for read_group groupby/aggregate paths; multi-child guard now trips only on more than one O2M edge (M2O chaining cannot fan out).
- tests: deeper fixtures (Country/City/Product) plus N-level WHERE, aggregation, and async cases.
- examples: demo sections for deep relational filtering and grouping.

Addressed: #2 